### PR TITLE
patch for sparql_io.sql

### DIFF
--- a/libsrc/Wi/sparql_io.sql
+++ b/libsrc/Wi/sparql_io.sql
@@ -1206,7 +1206,7 @@ create procedure DB.DBA.SPARQL_RESULTS_RDFXML_WRITE_ROW (inout ses any, in mdta 
 	      _val := __rdf_sqlval_of_obj (_val, 1);
 	      if (__tag (_val) = __tag of varchar) -- UTF-8 value kept in a DV_STRING box
 		_val := charset_recode (_val, 'UTF-8', '_WIDE_');
-	      http_value (__rdf_strsqlval (_val), 0, ses);
+	      http_value (_val, 0, ses);
 	    }
           http ('</res:value></res:binding>', ses);
         }

--- a/libsrc/Wi/sparql_io.sql
+++ b/libsrc/Wi/sparql_io.sql
@@ -1078,7 +1078,7 @@ create procedure DB.DBA.SPARQL_RESULTS_XML_WRITE_ROW (inout ses any, in mdta any
 	  if (__tag (sql_val) = __tag of varchar) -- UTF-8 value kept in a DV_STRING box
 	    sql_val := charset_recode (sql_val, 'UTF-8', '_WIDE_');
 	  if (is_xml_lit) http ('<![CDATA[', ses);
-	  http_value (__rdf_strsqlval (sql_val), 0, ses);
+	  http_value (sql_val, 0, ses);
 	  if (is_xml_lit) http (']]>', ses);
           http ('</literal></binding>', ses);
         }


### PR DESCRIPTION
This changes fix non-ASCII character issues in SPARQL Results. 

See http://sourceforge.net/tracker/?func=detail&aid=3552252&group_id=190976&atid=935521.
