### PR TITLE
Replace CVS with git

### DIFF
--- a/README
+++ b/README
@@ -52,7 +52,7 @@ Introduction
 ============
 
 This document explains steps to take after obtaining a Virtuoso source
-snapshot or cvs checkout.
+snapshot or git clone.
 
 These sections explain how to compile, test and install and what
 components are produced by the make process and how one can interact
@@ -143,7 +143,7 @@ Make FAQ
 
 In the root directory of the checkout perform the following commands:
 
-    ./autogen.sh        # should only be needed in CVS checkout
+    ./autogen.sh        # should only be needed in git clone
     ./configure
     make
 


### PR DESCRIPTION
The README still mentioned CVS although git is used now. Fixed this.
