### PR TITLE
SPARQL. LOAD <…> INTO <…>. File size limit

### DIFF
--- a/libsrc/Wi/bif_file.c
+++ b/libsrc/Wi/bif_file.c
@@ -629,7 +629,7 @@ bif_file_to_string (caddr_t * qst, caddr_t * err_ret, state_slot_t ** args)
   if (bytes > FS_MAX_STRING)
     {
       err = srv_make_new_error ("39000", "FA008",
-        "File '%.1000s' too long, cannot return string content %ld chars long", fname_cvt, (long)bytes );
+        "File '%.1000s' is too large (%ld bytes), cannot return string content larger than %ld bytes", fname_cvt, (long)bytes, (long)FS_MAX_STRING );
       goto signal_error;
     }
 


### PR DESCRIPTION
Looks like there is a file size limit on `LOAD <…> INTO <…>` command. I use it to import datasets from filesystem on-demand. It works fine for small datasets, but fails for larger ones.

I got this error:

```
Virtuoso 39000 Error FA008: File '/path/to/file.nt' too long, cannot return string content 62172163 chars long
```

In this case, file in question is [DBPedia "instance types" dictionary](http://downloads.dbpedia.org/3.8/en/instance_types_en.nt)
