### PR TITLE
hardcoded gmake

### DIFF
--- a/binsrc/sqldoc/vspx_doc.sh
+++ b/binsrc/sqldoc/vspx_doc.sh
@@ -28,6 +28,8 @@ LANG=C
 LC_ALL=POSIX
 export LANG LC_ALL
 
+MAKE=`which gmake|which make`
+
 vspxdir="${HOME}/binsrc/vspx"
 vspxsql=${vspxsql-$vspxdir/vspx.sql}
 vspxxsd=${vspxxsd-$vspxdir/vspx.xsd}
@@ -40,8 +42,10 @@ else
     cutter="${cutterdir}/cutter"
 fi
 pwddir=`pwd`
+
 cd "${cutterdir}"
-gmake
+$MAKE
+
 cd "${pwddir}"
 
 begin_xml ()


### PR DESCRIPTION
I was getting the following error while building on OS X:

```
=====================================================================
=  CREATING DOC DATABASE (mkdoc.sh)
=  Thu Mar 28 18:44:08 MSK 2013
=====================================================================

vspx_doc.sh: line 44: gmake: command not found
```

Build was continuing ignoring the error. This commit helps shell-script to find `make` command
