### PR TITLE
rdfcol.sql: Disable transaction log for insert-select query

### DIFF
--- a/libsrc/Wi/rdfcol.sql
+++ b/libsrc/Wi/rdfcol.sql
@@ -46,4 +46,9 @@ create distinct no primary key ref column index RDF_QUAD_GS on RDF_QUAD (G, S) p
 create distinct no primary key ref column index RDF_QUAD_OP on RDF_QUAD (O, P) partition (O varchar (-1, 0hexffff))
 ;
 
+-- disable transaction log and use autocommit
+-- as result of query might be too large to fit into transaction
+log_enable(2, 1);
 insert into rdf_quad (g,s,p,o) select g,s,p,o from rq_rows;
+-- reenable transaction log
+log_enable(1, 1);


### PR DESCRIPTION
While running script, which converts RDF-storage to Column-indices transaction log doesn't let conversion of large dataset to happen, so it has to be disabled while `insert…select` query is running
