### PR TITLE
Fixed 'Too many open statements' error for Iterator-based finder methods...

### DIFF
--- a/binsrc/jena/virtuoso_driver/VirtGraph.java
+++ b/binsrc/jena/virtuoso_driver/VirtGraph.java
@@ -678,7 +678,7 @@ public class VirtGraph extends GraphBase
       {
         java.sql.PreparedStatement stmt;
         stmt = prepareStatement(sb.toString());
-	return new VirtResSetIter(this, stmt.executeQuery(), tm);
+	return new VirtResSetIter(this, stmt, stmt.executeQuery(), tm);
       } catch (Exception e) {
         throw new JenaException(e);
       }

--- a/binsrc/jena/virtuoso_driver/VirtResSetIter.java
+++ b/binsrc/jena/virtuoso_driver/VirtResSetIter.java
@@ -35,21 +35,23 @@ import com.hp.hpl.jena.rdf.model.*;
 
 public class VirtResSetIter extends NiceIterator<Triple>
 {
-    protected ResultSet 	v_resultSet;
-    protected Triple 		v_row;
-    protected TripleMatch 	v_in;
-    protected boolean 		v_finished = false;
-    protected boolean 		v_prefetched = false;
-    protected VirtGraph         v_graph = null;
+    protected ResultSet 	 v_resultSet;
+    protected java.sql.Statement v_statement;
+    protected Triple 		 v_row;
+    protected TripleMatch 	 v_in;
+    protected boolean 		 v_finished = false;
+    protected boolean 		 v_prefetched = false;
+    protected VirtGraph          v_graph = null;
 
     public VirtResSetIter()
     {
         v_finished = true;
     }
 
-    public VirtResSetIter(VirtGraph graph, ResultSet resultSet, TripleMatch in)
+    public VirtResSetIter(VirtGraph graph, java.sql.Statement statement, ResultSet resultSet, TripleMatch in)
     {
         v_resultSet = resultSet;
+        v_statement = statement;
 	v_in = in;
 	v_graph = graph;
     }
@@ -153,6 +155,8 @@ public class VirtResSetIter extends NiceIterator<Triple>
 		{
 		    v_resultSet.close();
 		    v_resultSet = null;
+                    v_statement.close();
+                    v_statement = null;
 		}
 		catch (SQLException e)
 		{

--- a/binsrc/jena2/virtuoso_driver/VirtGraph.java
+++ b/binsrc/jena2/virtuoso_driver/VirtGraph.java
@@ -710,7 +710,7 @@ public class VirtGraph extends GraphBase
       {
         java.sql.PreparedStatement stmt;
         stmt = prepareStatement(sb.toString());
-	return new VirtResSetIter(this, stmt.executeQuery(), tm);
+	return new VirtResSetIter(this, stmt, stmt.executeQuery(), tm);
       } catch (Exception e) {
         throw new JenaException(e);
       }

--- a/binsrc/jena2/virtuoso_driver/VirtResSetIter.java
+++ b/binsrc/jena2/virtuoso_driver/VirtResSetIter.java
@@ -36,6 +36,7 @@ import com.hp.hpl.jena.rdf.model.*;
 public class VirtResSetIter extends NiceIterator<Triple>
 {
     protected ResultSet 	v_resultSet;
+    protected java.sql.Statement 	v_statement;
     protected Triple 		v_row;
     protected TripleMatch 	v_in;
     protected boolean 		v_finished = false;
@@ -47,9 +48,10 @@ public class VirtResSetIter extends NiceIterator<Triple>
         v_finished = true;
     }
 
-    public VirtResSetIter(VirtGraph graph, ResultSet resultSet, TripleMatch in)
+    public VirtResSetIter(VirtGraph graph, java.sql.Statement statement, ResultSet resultSet, TripleMatch in)
     {
         v_resultSet = resultSet;
+        v_statement = statement;
 	v_in = in;
 	v_graph = graph;
     }
@@ -153,6 +155,8 @@ public class VirtResSetIter extends NiceIterator<Triple>
 		{
 		    v_resultSet.close();
 		    v_resultSet = null;
+                    v_statement.close();
+                    v_statement = null;
 		}
 		catch (SQLException e)
 		{

--- a/binsrc/jena2/virtuoso_driver/VirtResSetIter2.java
+++ b/binsrc/jena2/virtuoso_driver/VirtResSetIter2.java
@@ -36,6 +36,7 @@ import com.hp.hpl.jena.rdf.model.*;
 public class VirtResSetIter2 implements Iterator<Triple>
 {
     protected ResultSet 	v_resultSet;
+    protected java.sql.Statement 	v_statement;
     protected Triple 		v_row;
     protected boolean 		v_finished = false;
     protected boolean 		v_prefetched = false;
@@ -46,9 +47,10 @@ public class VirtResSetIter2 implements Iterator<Triple>
         v_finished = true;
     }
 
-    public VirtResSetIter2(VirtGraph graph, ResultSet resultSet)
+    public VirtResSetIter2(VirtGraph graph, java.sql.Statement statement, ResultSet resultSet)
     {
         v_resultSet = resultSet;
+        v_statement = statement;
 	v_graph = graph;
     }
 
@@ -142,6 +144,8 @@ public class VirtResSetIter2 implements Iterator<Triple>
 		{
 		    v_resultSet.close();
 		    v_resultSet = null;
+                    v_statement.close();
+		    v_statement = null;
 		}
 		catch (SQLException e)
 		{

--- a/binsrc/jena2/virtuoso_driver/VirtuosoQueryExecution.java
+++ b/binsrc/jena2/virtuoso_driver/VirtuosoQueryExecution.java
@@ -189,7 +189,7 @@ public class VirtuosoQueryExecution  implements QueryExecution
         if (timeout > 0)
           stmt.setQueryTimeout((int)(timeout/1000));
         java.sql.ResultSet rs = stmt.executeQuery(getVosQuery());
-        return new VirtResSetIter2(graph, rs);
+        return new VirtResSetIter2(graph, stmt, rs);
 
       } catch (Exception e) {
         throw new JenaException("execConstructTriples was FAILED.:"+e);
@@ -246,7 +246,7 @@ public class VirtuosoQueryExecution  implements QueryExecution
         if (timeout > 0)
           stmt.setQueryTimeout((int)(timeout/1000));
         java.sql.ResultSet rs = stmt.executeQuery(getVosQuery());
-        return new VirtResSetIter2(graph, rs);
+        return new VirtResSetIter2(graph, stmt, rs);
 
       } catch (Exception e) {
         throw new JenaException("execDescribeTriples was FAILED.:"+e);


### PR DESCRIPTION
This commit complements e6fde53:develop/6 in openlink/virtuoso-opensource.

When closing an `Iterator` used for finding triples, its corresponding Java SQL `ResultSet` is also closed, but not the SQL `Statement` that the `ResultSet` belongs to. If many finder queries are used, a 'Too many open statements' is thrown by Virtuoso, even when correctly closing `Iterator`s.

This should also be merged into develop/7.
