### PR TITLE
do not mask SIGSEGV to hide real crash culprit/place

### DIFF
--- a/binsrc/virtuoso/viunix.c
+++ b/binsrc/virtuoso/viunix.c
@@ -308,7 +308,10 @@ sigh_set_notifiers ()
 	  i != SIGTERM &&
 	  i != SIGHUP  &&
 	  i != SIGQUIT &&
-	  i != SIGPIPE)
+	  i != SIGPIPE &&
+          i != SIGSEGV) /* if we handle SIGSEGV, then crash backtrace
+                           will point to us instead of to the real
+                           crash place */
 	{
 	  if (SIG_ERR == signal (i, sigh_report_and_forget))
 	    {

--- a/libsrc/Dk/Dktypes.h
+++ b/libsrc/Dk/Dktypes.h
@@ -190,7 +190,7 @@ typedef long long 		int64;
 #endif
 #endif
 
-#ifdef WIN32
+#if defined(WIN32) || (defined(SOLARIS) && defined(__GNUC__))
 #define INFINITY (DBL_MAX+DBL_MAX)
 #define NAN (INFINITY-INFINITY)
 #endif


### PR DESCRIPTION
Hi, this solves issue #202
