### PR TITLE
Fix dependencies available on debian jessie

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Build-Depends: cdbs, debhelper (>= 7), quilt, autotools-dev, autoconf (>=2.57),
  libmono-corlib2.0-cil (>= 1.2.6) [i386 kfreebsd-i386 powerpc amd64 kfreebsd-amd64 ia64 arm armeb armel sparc s390],
  libmono-system-data2.0-cil (>= 1.0) [i386 kfreebsd-i386 powerpc amd64 kfreebsd-amd64 ia64 arm armeb armel sparc s390],
  libmono-system2.0-cil (>= 1.2.6) [i386 kfreebsd-i386 powerpc amd64 kfreebsd-amd64 ia64 arm armeb armel sparc s390],
- docbook2x, po-debconf, libmagickwand-dev, openjdk-6-jdk, openjdk-7-jdk
+ docbook2x, po-debconf, libmagickwand-dev, openjdk-7-jdk
 
 Package: virtuoso-nepomuk
 Architecture: all

--- a/debian/rules
+++ b/debian/rules
@@ -12,8 +12,6 @@ DEB_AUTO_UPDATE_LIBTOOL = pre
 
 DEB_AUTOMAKE_ARGS += -Wno-portability
 
-JDK6PATH = $(shell dpkg -L openjdk-6-jdk | grep "/usr/lib/jvm/java-6-openjdk" | cut -d - -f 1-4| cut -d / -f 1-5 | sort -u )
-
 JDK7PATH = $(shell dpkg -L openjdk-7-jdk | grep "/usr/lib/jvm/java-7-openjdk" | cut -d - -f 1-4| cut -d / -f 1-5 | sort -u)
 
 DEB_CONFIGURE_EXTRA_FLAGS = --with-layout=debian \
@@ -29,7 +27,6 @@ DEB_CONFIGURE_EXTRA_FLAGS = --with-layout=debian \
 		--enable-sparqldemo-vad \
 		--enable-syncml-vad \
 		--enable-bpel-vad \
-		--with-jdk4=$(JDK6PATH) \
 		--with-jdk4_1=$(JDK7PATH)
 
 ifeq ($(DEB_BUILD_ARCH),alpha)


### PR DESCRIPTION
Fix #342.
This pull request removes the dependency to openjdk-6-jdk which is no longer available in debian jessie and ubuntu
