### PR TITLE
Fix a typo in the documentation

### DIFF
--- a/docsrc/xmlsource/backup.xml
+++ b/docsrc/xmlsource/backup.xml
@@ -326,7 +326,7 @@ The general steps to rebuild a database are:
 the SHUTDOWN command from interactive SQL.</para></listitem>
     <listitem><para>Make sure there is a log file specified in virtuoso.ini.</para></listitem>
     <listitem><para>Start the server process virtuoso with the -b command line
-option: e.g. % ./virtuoso -b (+backup_dump)</para>
+option: e.g. % ./virtuoso -b (+backup-dump)</para>
 <para>This will write the contents of the database into the log file specified
 in virtuoso.ini and exit when complete.</para></listitem>
     <listitem><para>Take a backup of the old database file.</para></listitem>


### PR DESCRIPTION
backup_dump was mentioned in the documentation instead of backup-dump
