### PR TITLE
Fixed conversion of broken unicode strings.

### DIFF
--- a/libsrc/JDBCDriverType4/virtuoso/jdbc2/VirtuosoInputStream.java
+++ b/libsrc/JDBCDriverType4/virtuoso/jdbc2/VirtuosoInputStream.java
@@ -535,6 +535,7 @@ class VirtuosoInputStream extends BufferedInputStream
                     break;
                 default:
                     /* 10xx xxxx,  1111 xxxx */
+                    count++;
                     c_arr[ch_count++] = bad_char;
 /**
                     throw new UTFDataFormatException("malformed input around byte " + count);


### PR DESCRIPTION
The count variable was never increased for invalid chars which can
eventually lead to an IndexOutOfBoundsException.
