### PR TITLE
JDBC: Finalizer method on VirtuosoRow is not needed,

### DIFF
--- a/libsrc/JDBCDriverType4/virtuoso/jdbc2/VirtuosoFuture.java
+++ b/libsrc/JDBCDriverType4/virtuoso/jdbc2/VirtuosoFuture.java
@@ -222,19 +222,5 @@ class VirtuosoFuture
          return ((VirtuosoFuture)obj).req_no == req_no;
       return false;
    }
-
-   /**
-    * Method runs when the garbage collector want to erase the object
-    */
-   public void finalize() throws Throwable
-   {
-      connection = null;
-      if(results != null)
-      {
-         results.removeAllElements();
-         results = null;
-      }
-   }
-
 }
 

--- a/libsrc/JDBCDriverType4/virtuoso/jdbc2/VirtuosoRow.java
+++ b/libsrc/JDBCDriverType4/virtuoso/jdbc2/VirtuosoRow.java
@@ -1014,19 +1014,6 @@ class VirtuosoRow
        return content;
    }
 
-   /**
-    * Method runs when the garbage collector want to erase the object
-    */
-   public void finalize() throws Throwable
-   {
-      if(content != null)
-      {
-         content.removeAllElements();
-         content = null;
-      }
-      resultSet = null;
-   }
-
    public String toString ()
      {
        if (content == null)


### PR DESCRIPTION
Clean up code is much slower than letting GC run and can lead to GC overhead exceptions. This is due to too the length of the finalizer queue. Which means the finalizer does not finish in the alloted time slot.

This has led too 2 downtime events  for us. 

As only code is deleted copyright on the patch remains with openlinksw.
