### PR TITLE
Travis CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,107 @@
+language: C
+matrix:
+  include:
+    # works on Precise and Trusty
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
+            - autoconf 
+            - automake 
+            - libtool 
+            - flex 
+            - bison 
+            - gperf 
+            - gawk 
+            - m4 
+            - make 
+            - odbcinst 
+            - libxml2-dev 
+            - libssl-dev 
+            - libreadline-dev
+      env:
+         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+
+    # works on Precise and Trusty
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+            - autoconf 
+            - automake 
+            - libtool 
+            - flex 
+            - bison 
+            - gperf 
+            - gawk 
+            - m4 
+            - make 
+            - odbcinst 
+            - libxml2-dev 
+            - libssl-dev 
+            - libreadline-dev
+      env:
+         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+
+    # works on Precise and Trusty
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+            - autoconf 
+            - automake 
+            - libtool 
+            - flex 
+            - bison 
+            - gperf 
+            - gawk 
+            - m4 
+            - make 
+            - odbcinst 
+            - libxml2-dev 
+            - libssl-dev 
+            - libreadline-dev
+      env:
+        - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+    # works on Precise and Trusty
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+            - autoconf 
+            - automake 
+            - libtool 
+            - flex 
+            - bison 
+            - gperf 
+            - gawk 
+            - m4 
+            - make 
+            - odbcinst 
+            - odbcinst 
+            - libxml2-dev 
+            - libssl-dev 
+            - libreadline-dev
+      env:
+        - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6 && CONFIGFLAG='--with-debug'"
+
+before_install:
+        - eval "${MATRIX_EVAL}"
+
+script:
+    - ./autogen.sh;
+    - ./configure "${CONFIGFLAG}"
+    - make all
+    - make check


### PR DESCRIPTION
An Travis-CI setup to test with multiple C compilers and config options it allows the opensource version branches to be tested automatically. It would help avoid issues such as [695](https://github.com/openlink/virtuoso-opensource/issues/695)