### PR TITLE
bison 3 wants %pure-parser instead of %pure_parser

### DIFF
--- a/libsrc/Wi/nquad_p.y
+++ b/libsrc/Wi/nquad_p.y
@@ -21,7 +21,7 @@
  *
  */
 
-%pure_parser
+%pure-parser
 %parse-param {ttlp_t * ttlp_arg}
 %parse-param {yyscan_t yyscanner}
 %lex-param {ttlp_t * ttlp_arg}

--- a/libsrc/Wi/sparql_p.y
+++ b/libsrc/Wi/sparql_p.y
@@ -36,7 +36,7 @@ One tab before end of single-line BNF comment.
 
 Whitespaces in all other places, including two whitespaces after "::=" in BNF comments */
 
-%pure_parser
+%pure-parser
 %parse-param {sparp_t * sparp_arg}
 %lex-param {sparp_t * sparp_arg}
 %expect 14

--- a/libsrc/Wi/sql3.y
+++ b/libsrc/Wi/sql3.y
@@ -25,7 +25,7 @@
  *
  */
 
-%pure_parser
+%pure-parser
 %parse-param {yyscan_t scanner}
 %lex-param {yyscan_t scanner}
 /*%parse-param {sql_comp_context_t* scs_arg}*/

--- a/libsrc/Wi/turtle_p.y
+++ b/libsrc/Wi/turtle_p.y
@@ -21,7 +21,7 @@
  *
  */
 
-%pure_parser
+%pure-parser
 %parse-param {ttlp_t * ttlp_arg}
 %parse-param {yyscan_t yyscanner}
 %lex-param {ttlp_t * ttlp_arg}

--- a/libsrc/Wi/xpathp.y
+++ b/libsrc/Wi/xpathp.y
@@ -25,7 +25,7 @@
  *
  */
 
-%pure_parser
+%pure-parser
 %parse-param {xpp_t * xpp_arg}
 %lex-param {xpp_t * xpp_arg}
 


### PR DESCRIPTION
Small warning only and should still work on bison2 systems