### PR TITLE
Fix the NPD occurred in short-circuit evaluation.

### DIFF
--- a/libsrc/Wi/bif_intl.c
+++ b/libsrc/Wi/bif_intl.c
@@ -1055,7 +1055,7 @@ intl_find_user_charset (const char *encname, int xml_input_is_wide)
   wcharset_t **charset;
   encoding_handler_t *eh = NULL;
 
-  if (!encname && !*encname)
+  if (!encname || !*encname)
     return eh;
 
   inx1 = 0;

--- a/libsrc/util/buildarg.c
+++ b/libsrc/util/buildarg.c
@@ -116,7 +116,7 @@ build_argv_from_string (const char *s, int *pargc, char ***pargv)
 	      if (++argc >= nargv - 1)
 		{
 		  nargv += INCR;
-		  argv = (char **) s_realloc (argv, nargv * sizeof (char **));
+		  argv = (char **) s_realloc (argv, nargv * sizeof (char *));
 		}
 	    }
 	  optptr = option;
@@ -135,7 +135,7 @@ build_argv_from_string (const char *s, int *pargc, char ***pargv)
   *pargc = argc;
   *pargv = argv;
   if (argc >= nargv)
-    argv = (char **) s_realloc (argv, ++nargv * sizeof (char **));
+    argv = (char **) s_realloc (argv, ++nargv * sizeof (char *));
   while (argc < nargv)
     argv[argc++] = NULL;
 


### PR DESCRIPTION
When `encname` is a null pointer, there will be a null pointer dereference in the short-circuit evaluation.

Found by the static analyzer of Qihoo360 CodeSafe Team!