### PR TITLE
Fixed errors in fct

### DIFF
--- a/binsrc/fct/grants.sql
+++ b/binsrc/fct/grants.sql
@@ -52,6 +52,7 @@ grant execute on DB.DBA.DAV_SEARCH_PATH to "SPARQL_SELECT";
 grant execute on DB.DBA.VT_INC_INDEX_DB_DBA_RDF_OBJ to "SPARQL_SELECT";
 grant execute on DB.DBA.fct_do_desc_rset to "SPARQL_SELECT";
 grant execute on b3s_lbl_order to "SPARQL_SELECT";
+grant execute on DB.DBA.FCT_GRAPH_USAGE_SUMMARY to "SPARQL_SELECT";
 grant execute on DB.DBA.RDF_SPONGE_AUTH to "SPARQL_SELECT";
 grant execute on b3s_u2w to "SPARQL_SELECT";
 grant execute on DB.DBA.lp_score_ck to "SPARQL_SELECT";

--- a/binsrc/fct/rdfdesc/usage.vsp
+++ b/binsrc/fct/rdfdesc/usage.vsp
@@ -43,6 +43,7 @@
   declare ses_params varchar;
   declare pageUrl varchar;
   declare user_permissions int;
+  declare q_txt any;
 
   white_page := 1;
 


### PR DESCRIPTION
This PR fixes two errors in fct:
* Fixes #787.
* Fixes `SR186:SECURITY: No permission to execute procedure DB.DBA.FCT_GRAPH_USAGE_SUMMARY with user ID 107, group ID 107` when accessing the page usage.vsp.