### PR TITLE
Change priority of type selection for DBpedia plugin

### DIFF
--- a/binsrc/dbpedia/vsp/description.sql
+++ b/binsrc/dbpedia/vsp/description.sql
@@ -351,13 +351,15 @@ create procedure dbp_ldd_type (in gr varchar, in subj varchar, out url varchar, 
 
       langs := dbp_ldd_get_default_lang_acc (lines);
 
-      exec (sprintf ('sparql select (sql:BEST_LANGMATCH (?l, \'%S\', \'\')) ?tp from <%S> from virtrdf:schemas { `iri(??)` <http://dbpedia.org/ontology/type>  ?tp . optional { ?tp rdfs:label ?l } }', langs, gr), null, null, vector (subj), 0, meta, data);
+      exec (sprintf ('sparql select (sql:BEST_LANGMATCH (?l, \'%S\', \'\')) ?tp from <%S> from virtrdf:schemas { `iri(??)` a ?tp . optional { ?tp rdfs:label ?l } }', langs, gr),
+      	null, null, vector (subj), 0, meta, data);
+      
       if (not length (data))
         exec (sprintf ('sparql select (sql:BEST_LANGMATCH (?l, \'%S\', \'\')) ?tp from <%S> from virtrdf:schemas { `iri(??)` a ?tp . optional { ?tp rdfs:label ?l } filter (?tp like <http://dbpedia.org/ontology/%%>) }', langs, gr),
 	  null, null, vector ( subj), 0, meta, data);
       if (not length (data))
-        exec (sprintf ('sparql select (sql:BEST_LANGMATCH (?l, \'%S\', \'\')) ?tp from <%S> from virtrdf:schemas { `iri(??)` a ?tp . optional { ?tp rdfs:label ?l } }', langs, gr),
-	  null, null, vector (subj), 0, meta, data);
+        exec (sprintf ('sparql select (sql:BEST_LANGMATCH (?l, \'%S\', \'\')) ?tp from <%S> from virtrdf:schemas { `iri(??)` <http://dbpedia.org/ontology/type>  ?tp . optional { ?tp rdfs:label ?l } }', langs, gr), null, null, vector (subj), 0, meta, data);
+	
       if (length (data))
 	{
 	  if (data[0][0] is not null and data[0][0] <> 0)


### PR DESCRIPTION
Current way of selecting a type for a resource:
* First: Check for ontology/type property
* Fallback: Check for rdf:Type 

Proposed way of selecting type:
* First: Check for rdf:Type
* Fallback: Check for ontology/type

rdf:Type is more frequently used and usually the correct type.