### PR TITLE
numeric.c: include util/strfuns.h for stricmp()

### DIFF
--- a/libsrc/Wi/numeric.c
+++ b/libsrc/Wi/numeric.c
@@ -27,6 +27,7 @@
 
 #include "Dk.h"
 #include "numeric.h"
+#include "util/strfuns.h"
 
 /* activates code for divmod, modulo, powmod, pow, sqr */
 #define NUMERIC_EXTS	1


### PR DESCRIPTION
On macOS, Xcode as of version 12 considers implicit function declarations to be an error rather than a warning. One instance of this is in libsrc/Wi/numeric.c:
```
numeric.c:1527:12: error: implicit declaration of function 'stricmp' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
      if (!stricmp (cp, "INF") \|\| !stricmp (cp, "Infinity"))
           ^
numeric.c:1680:29: error: implicit declaration of function 'stricmp' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
  if (!isdigit (cp[0]) && (!stricmp (cp, "INF") \|\| !stricmp (cp, "Infinity") \|\| !stricmp (cp, "NaN")))
                            ^
```

Including libsrc/utils/strfuns.h (which declares `stricmp()`) resolves the issue in libsrc/Wi/numeric.c.