### PR TITLE
Do not use new Long/Byte/Short/Character etc.

### DIFF
--- a/libsrc/JDBCDriverType4/virtuoso/javax/BaseRowSet.java
+++ b/libsrc/JDBCDriverType4/virtuoso/javax/BaseRowSet.java
@@ -997,7 +997,7 @@ public abstract class BaseRowSet implements RowSet, Serializable {
   {
     Parameter param = getParam(parameterIndex);
 
-    param.value = new Boolean(x);
+    param.value = Boolean.valueOf(x);
     param.jType = Parameter.jObject;
   }
 
@@ -1013,7 +1013,7 @@ public abstract class BaseRowSet implements RowSet, Serializable {
   {
     Parameter param = getParam(parameterIndex);
 
-    param.value = new Byte(x);
+    param.value = Byte.valueOf(x);
     param.jType = Parameter.jObject;
   }
 
@@ -1322,7 +1322,7 @@ public abstract class BaseRowSet implements RowSet, Serializable {
   {
     Parameter param = getParam(parameterIndex);
 
-    param.value = new Double(x);
+    param.value = Double.valueOf(x);
     param.jType = Parameter.jObject;
   }
 
@@ -1339,7 +1339,7 @@ public abstract class BaseRowSet implements RowSet, Serializable {
   {
     Parameter param = getParam(parameterIndex);
 
-    param.value = new Float(x);
+    param.value = Float.valueOf(x);
     param.jType = Parameter.jObject;
   }
 
@@ -1355,7 +1355,7 @@ public abstract class BaseRowSet implements RowSet, Serializable {
   {
     Parameter param = getParam(parameterIndex);
 
-    param.value = new Integer(x);
+    param.value = Integer.valueOf(x);
     param.jType = Parameter.jObject;
   }
 
@@ -1371,7 +1371,7 @@ public abstract class BaseRowSet implements RowSet, Serializable {
   {
     Parameter param = getParam(parameterIndex);
 
-    param.value = new Long(x);
+    param.value = Long.valueOf(x);
     param.jType = Parameter.jObject;
   }
 
@@ -1402,7 +1402,7 @@ public abstract class BaseRowSet implements RowSet, Serializable {
   {
     Parameter param = getParam(parameterIndex);
 
-    param.value = new Short(x);
+    param.value = Short.valueOf(x);
     param.jType = Parameter.jObject;
   }
 

--- a/libsrc/JDBCDriverType4/virtuoso/javax/OPLCachedRowSet.java
+++ b/libsrc/JDBCDriverType4/virtuoso/javax/OPLCachedRowSet.java
@@ -2349,7 +2349,7 @@ public class OPLCachedRowSet extends BaseRowSet
     Row r = this.getRowForUpdate(columnIndex, "'updateBoolean(...)'");
     switch(rowSMD.getColumnType(columnIndex)) {
      case Types.BOOLEAN:
-        r.setColData(columnIndex, new Boolean(x));
+        r.setColData(columnIndex, Boolean.valueOf(x));
         break;
       case Types.BIT:
       case Types.TINYINT:
@@ -2361,7 +2361,7 @@ public class OPLCachedRowSet extends BaseRowSet
       case Types.DOUBLE:
       case Types.DECIMAL:
       case Types.NUMERIC:
-        r.setColData(columnIndex, new Integer((x ?1:0)));
+        r.setColData(columnIndex, Integer.valueOf((x ?1:0)));
         break;
       case Types.CHAR:
       case Types.VARCHAR:
@@ -2389,7 +2389,7 @@ public class OPLCachedRowSet extends BaseRowSet
    * @exception SQLException if a database-access error occurs
    */
   public void updateByte(int columnIndex, byte x) throws SQLException {
-    updateNumber(columnIndex, new Byte(x), "'byte'", "'updateByte(...)'");
+    updateNumber(columnIndex, Byte.valueOf(x), "'byte'", "'updateByte(...)'");
   }
 
   /**
@@ -2405,7 +2405,7 @@ public class OPLCachedRowSet extends BaseRowSet
    * @exception SQLException if a database-access error occurs
    */
   public void updateShort(int columnIndex, short x) throws SQLException {
-    updateNumber(columnIndex, new Short(x), "'short'", "'updateShort(...)'");
+    updateNumber(columnIndex, Short.valueOf(x), "'short'", "'updateShort(...)'");
   }
 
   /**
@@ -2421,7 +2421,7 @@ public class OPLCachedRowSet extends BaseRowSet
    * @exception SQLException if a database-access error occurs
    */
   public void updateInt(int columnIndex, int x) throws SQLException {
-    updateNumber(columnIndex, new Integer(x), "'int'", "'updateInt(...)'");
+    updateNumber(columnIndex, Integer.valueOf(x), "'int'", "'updateInt(...)'");
   }
 
   /**
@@ -2437,7 +2437,7 @@ public class OPLCachedRowSet extends BaseRowSet
    * @exception SQLException if a database-access error occurs
    */
   public void updateLong(int columnIndex, long x) throws SQLException {
-    updateNumber(columnIndex, new Long(x), "'long'", "'updateLong(...)'");
+    updateNumber(columnIndex, Long.valueOf(x), "'long'", "'updateLong(...)'");
   }
 
   /**
@@ -2453,7 +2453,7 @@ public class OPLCachedRowSet extends BaseRowSet
    * @exception SQLException if a database-access error occurs
    */
   public void updateFloat(int columnIndex, float x) throws SQLException {
-    updateNumber(columnIndex, new Float(x), "'float'", "'updateFloat(...)'");
+    updateNumber(columnIndex, Float.valueOf(x), "'float'", "'updateFloat(...)'");
   }
 
   /**
@@ -2469,7 +2469,7 @@ public class OPLCachedRowSet extends BaseRowSet
    * @exception SQLException if a database-access error occurs
    */
   public void updateDouble(int columnIndex, double x) throws SQLException {
-    updateNumber(columnIndex, new Double(x), "'double'", "'updateDouble(...)'");
+    updateNumber(columnIndex, Double.valueOf(x), "'double'", "'updateDouble(...)'");
   }
 
   /**
@@ -2510,7 +2510,7 @@ public class OPLCachedRowSet extends BaseRowSet
     else
       switch(rowSMD.getColumnType(columnIndex)) {
       case Types.BOOLEAN:
-        r.setColData(columnIndex, new Boolean(x));
+        r.setColData(columnIndex, Boolean.parseBoolean(x));
         break;
       case Types.BIT:
       case Types.TINYINT:
@@ -5273,7 +5273,7 @@ public class OPLCachedRowSet extends BaseRowSet
     Row r = this.getRowForUpdate(columnIndex, funcName);
     switch(rowSMD.getColumnType(columnIndex)) {
       case Types.BOOLEAN:
-        r.setColData(columnIndex, new Boolean((val.intValue()!=0? true:false)));
+        r.setColData(columnIndex, Boolean.valueOf((val.intValue()!=0? true:false)));
         break;
       case Types.BIT:
       case Types.TINYINT:
@@ -5688,14 +5688,14 @@ public class OPLCachedRowSet extends BaseRowSet
       query = sql.toCharArray();
       end = query.length - 1;
 
-      keywords.put("SELECT", new Integer(Token.T_SELECT));
-      keywords.put("FROM", new Integer(Token.T_FROM));
-      keywords.put("WHERE", new Integer(Token.T_WHERE));
-      keywords.put("ORDER", new Integer(Token.T_ORDER));
-      keywords.put("BY", new Integer(Token.T_BY));
-      keywords.put("GROUP", new Integer(Token.T_GROUP));
-      keywords.put("UNION", new Integer(Token.T_UNION));
-      keywords.put("HAVING", new Integer(Token.T_HAVING));
+      keywords.put("SELECT", Integer.valueOf(Token.T_SELECT));
+      keywords.put("FROM", Integer.valueOf(Token.T_FROM));
+      keywords.put("WHERE", Integer.valueOf(Token.T_WHERE));
+      keywords.put("ORDER", Integer.valueOf(Token.T_ORDER));
+      keywords.put("BY", Integer.valueOf(Token.T_BY));
+      keywords.put("GROUP", Integer.valueOf(Token.T_GROUP));
+      keywords.put("UNION", Integer.valueOf(Token.T_UNION));
+      keywords.put("HAVING", Integer.valueOf(Token.T_HAVING));
     }
 
     //  select_stmt =  SELECT [ ALL | DISTINCT ] select_item { "," select_item }
@@ -6269,7 +6269,7 @@ public class OPLCachedRowSet extends BaseRowSet
             tmpSQL.append(", ");
           tmpSQL.append(rsmd.getColumnName(i));
           tmpSQL.append(" = ? ");
-          setData.add(new Integer(i));
+          setData.add(Integer.valueOf(i));
         }
 
       tmpSQL.append(" WHERE ");

--- a/libsrc/JDBCDriverType4/virtuoso/jdbc/ConnectionWrapper.java
+++ b/libsrc/JDBCDriverType4/virtuoso/jdbc/ConnectionWrapper.java
@@ -152,7 +152,7 @@ public class ConnectionWrapper implements java.sql.Connection {
       check_conn();
 
       if (r_AutoCommit == null)  // save the initial autoCommit state
-         r_AutoCommit = new Boolean(getAutoCommit());
+         r_AutoCommit = Boolean.valueOf(getAutoCommit());
 
       rconn.setAutoCommit(autoCommit);
     } catch (SQLException ex) {
@@ -210,7 +210,7 @@ public class ConnectionWrapper implements java.sql.Connection {
       check_conn();
 
       if (r_ReadOnly == null)  // save the initial readOnly state
-         r_ReadOnly = new Boolean(isReadOnly());
+         r_ReadOnly = Boolean.valueOf(isReadOnly());
 
       rconn.setReadOnly(readOnly);
     } catch (SQLException ex) {
@@ -258,7 +258,7 @@ public class ConnectionWrapper implements java.sql.Connection {
       check_conn();
 
       if (r_TxnIsolation == null)  // save the initial TxnIsolation state
-         r_TxnIsolation = new Integer(getTransactionIsolation());
+         r_TxnIsolation = Integer.valueOf(getTransactionIsolation());
 
       rconn.setTransactionIsolation(level);
     } catch (SQLException ex) {
@@ -370,7 +370,7 @@ public class ConnectionWrapper implements java.sql.Connection {
       check_conn();
 
       if (r_Holdability == null)  // save the initial holdability state
-         r_Holdability = new Integer(getHoldability());
+         r_Holdability = Integer.valueOf(getHoldability());
 
       rconn.setHoldability(holdability);
     } catch (SQLException ex) {

--- a/libsrc/JDBCDriverType4/virtuoso/jdbc/Driver.java
+++ b/libsrc/JDBCDriverType4/virtuoso/jdbc/Driver.java
@@ -181,9 +181,9 @@ public class Driver implements java.sql.Driver
    {
     host = "localhost";
     port = "1111";
-    fbs = new Integer(VirtuosoTypes.DEFAULTPREFETCH);
-    sendbs = new Integer(32768);
-    recvbs = new Integer(32768);
+    fbs = Integer.valueOf(VirtuosoTypes.DEFAULTPREFETCH);
+    sendbs = Integer.valueOf(32768);
+    recvbs = Integer.valueOf(32768);
 
     Properties props = new Properties();
 

--- a/libsrc/JDBCDriverType4/virtuoso/jdbc/VirtuosoBlob.java
+++ b/libsrc/JDBCDriverType4/virtuoso/jdbc/VirtuosoBlob.java
@@ -281,13 +281,13 @@ public class VirtuosoBlob
 	       // we should go from start
 	       //System.out.println ("vb: rewind pos:" + pos + " ofs:" + bh_offset());
 	       rewind();
-//	       init_read_len = new Long ((pos - 1) *
+//	       init_read_len = Long.valueOf ((pos - 1) *
 //		   (dtp == VirtuosoTypes.DV_BLOB_WIDE_HANDLE ? -1 : 1));
-	       init_read_len = new Long (pos - 1);
+	       init_read_len = Long.valueOf (pos - 1);
 	     }
 	   else if (pos - 1 > bh_offset ())
-	     init_read_len = new Long (pos - bh_offset() - 1);
-//	     init_read_len = new Long ((pos - bh_offset() - 1) *
+	     init_read_len = Long.valueOf (pos - bh_offset() - 1);
+//	     init_read_len = Long.valueOf ((pos - bh_offset() - 1) *
 //		 (dtp == VirtuosoTypes.DV_BLOB_WIDE_HANDLE ? -1 : 1));
 ***/
 	   if (pos - 1 < bh_offset ())
@@ -298,7 +298,7 @@ public class VirtuosoBlob
 	     }
 
 	   if (pos - 1 > bh_offset ())
-	     init_read_len = new Long (pos - bh_offset() - 1);
+	     init_read_len = Long.valueOf (pos - bh_offset() - 1);
 
 
 	   if (init_read_len != null)
@@ -309,15 +309,15 @@ public class VirtuosoBlob
 		 {
 		   // skip the desired number of bytes
 		   Object[] args = new Object[9];
-		   args[0] = new Long(this.bh_current_page);
+		   args[0] = Long.valueOf(this.bh_current_page);
 		   args[1] = init_read_len;
-		   args[2] = new Long(this.bh_position);
-		   args[3] = new Long(this.key_id);
-		   args[4] = new Long(this.frag_no);
-		   args[5] = new Long(this.dir_page);
+		   args[2] = Long.valueOf(this.bh_position);
+		   args[3] = Long.valueOf(this.key_id);
+		   args[4] = Long.valueOf(this.frag_no);
+		   args[5] = Long.valueOf(this.dir_page);
 		   args[6] = this.pages;
-		   args[7] = this.dtp == VirtuosoTypes.DV_BLOB_WIDE_HANDLE ? new Long (1) : new Long(0);
-		   args[8] = new Long (this.bh_timestamp);
+		   args[7] = this.dtp == VirtuosoTypes.DV_BLOB_WIDE_HANDLE ? Long.valueOf (1) : Long.valueOf(0);
+		   args[8] = Long.valueOf (this.bh_timestamp);
 		   //System.out.println ("vb: init read FUTURE: " + this.bh_current_page + " " + init_read_len + " " + this.bh_position);
 		   VirtuosoFuture future = connection.getFuture(VirtuosoFuture.getdata,args, -1);
 		   curr = future.nextResult();
@@ -369,17 +369,17 @@ public class VirtuosoBlob
 	   synchronized (connection)
 	     {
 	       Object[] args = new Object[9];
-	       args[0] = new Long(this.bh_current_page);
-//	       args[1] = new Long(length *
+	       args[0] = Long.valueOf(this.bh_current_page);
+//	       args[1] = Long.valueOf(length *
 //		       (dtp == VirtuosoTypes.DV_BLOB_WIDE_HANDLE ? -1 : 1));
-	       args[1] = new Long(length);
-	       args[2] = new Long(this.bh_position);
-               args[3] = new Long(this.key_id);
-               args[4] = new Long(this.frag_no);
-               args[5] = new Long(this.dir_page);
+	       args[1] = Long.valueOf(length);
+	       args[2] = Long.valueOf(this.bh_position);
+               args[3] = Long.valueOf(this.key_id);
+               args[4] = Long.valueOf(this.frag_no);
+               args[5] = Long.valueOf(this.dir_page);
                args[6] = this.pages;
-	       args[7] = this.dtp == VirtuosoTypes.DV_BLOB_WIDE_HANDLE ? new Long (1) : new Long(0);
-	       args[8] = new Long (this.bh_timestamp);
+	       args[7] = this.dtp == VirtuosoTypes.DV_BLOB_WIDE_HANDLE ? Long.valueOf (1) : Long.valueOf(0);
+	       args[8] = Long.valueOf (this.bh_timestamp);
 	       //System.out.println ("vb: FUTURE: " + this.bh_current_page + " " + length + " " + this.bh_position);
 	       VirtuosoFuture future = connection.getFuture(VirtuosoFuture.getdata,args, -1);
 	       curr = future.nextResult();

--- a/libsrc/JDBCDriverType4/virtuoso/jdbc/VirtuosoCallableStatement.java
+++ b/libsrc/JDBCDriverType4/virtuoso/jdbc/VirtuosoCallableStatement.java
@@ -136,7 +136,7 @@ public class VirtuosoCallableStatement extends VirtuosoPreparedStatement impleme
             return;
          case Types.BIGINT:
             if (objparams.elementAt(parameterIndex - 1) == null)
-              objparams.setElementAt(new Long(Long.MAX_VALUE),parameterIndex - 1);
+              objparams.setElementAt(Long.valueOf(Long.MAX_VALUE),parameterIndex - 1);
             return;
          case Types.LONGVARBINARY:
          case Types.VARBINARY:
@@ -144,7 +144,7 @@ public class VirtuosoCallableStatement extends VirtuosoPreparedStatement impleme
             return;
          case Types.BIT:
             if (objparams.elementAt(parameterIndex - 1) == null)
-              objparams.setElementAt(new Boolean(false),parameterIndex - 1);
+              objparams.setElementAt(Boolean.FALSE,parameterIndex - 1);
             return;
          case Types.BLOB:
          case Types.CLOB:
@@ -175,7 +175,7 @@ public class VirtuosoCallableStatement extends VirtuosoPreparedStatement impleme
          case Types.FLOAT:
          case Types.DOUBLE:
             if (objparams.elementAt(parameterIndex - 1) == null)
-              objparams.setElementAt(new Double(Double.MAX_VALUE),parameterIndex - 1);
+              objparams.setElementAt(Double.valueOf(Double.MAX_VALUE),parameterIndex - 1);
             return;
          case Types.OTHER:
          case Types.JAVA_OBJECT:
@@ -188,16 +188,16 @@ public class VirtuosoCallableStatement extends VirtuosoPreparedStatement impleme
             return;
          case Types.REAL:
             if (objparams.elementAt(parameterIndex - 1) == null)
-              objparams.setElementAt(new Float(Float.MAX_VALUE),parameterIndex - 1);
+              objparams.setElementAt(Float.valueOf(Float.MAX_VALUE),parameterIndex - 1);
             return;
          case Types.SMALLINT:
             if (objparams.elementAt(parameterIndex - 1) == null)
-              objparams.setElementAt(new Short(Short.MAX_VALUE),parameterIndex - 1);
+              objparams.setElementAt(Short.valueOf(Short.MAX_VALUE),parameterIndex - 1);
             return;
          case Types.INTEGER:
          case Types.TINYINT:
             if (objparams.elementAt(parameterIndex - 1) == null)
-              objparams.setElementAt(new Integer(Integer.MAX_VALUE),parameterIndex - 1);
+              objparams.setElementAt(Integer.valueOf(Integer.MAX_VALUE),parameterIndex - 1);
             return;
       }
       ;

--- a/libsrc/JDBCDriverType4/virtuoso/jdbc/VirtuosoConnection.java
+++ b/libsrc/JDBCDriverType4/virtuoso/jdbc/VirtuosoConnection.java
@@ -457,11 +457,11 @@ public class VirtuosoConnection implements Connection
    {
        Object[] ret = new Object[7];
        ret[0] = new String ("JDBC");
-       ret[1] = new Integer (0);
+       ret[1] = Integer.valueOf(0);
        ret[2] = new String ("");
        ret[3] = System.getProperty("os.name");
        ret[4] = new String ("");
-       ret[5] = new Integer (0);
+       ret[5] = Integer.valueOf(0);
        //System.out.println (con_delegate);
        ret[6] = new String (con_delegate != null ? con_delegate : "");
        return ret;
@@ -656,15 +656,15 @@ public class VirtuosoConnection implements Connection
 				   {
 				     //System.err.println ("Mapping1 " + ((int)table.charAt(i)) + "=" + (i + 1));
 				     client_charset_hash.put (
-					 new Character (table.charAt(i)),
-					 new Byte ((byte) (i + 1)));
+					 Character.valueOf (table.charAt(i)),
+					 Byte.valueOf ((byte) (i + 1)));
 				   }
 				 else
 				   {
 				     //System.err.println ("Mapping2 " + (i + 1) + "=" + (i + 1));
 				     client_charset_hash.put (
-					 new Character ((char) (i + 1)),
-					 new Byte ((byte) (i + 1)));
+					 Character.valueOf ((char) (i + 1)),
+					 Byte.valueOf ((byte) (i + 1)));
 				   }
 			       }
 			   }
@@ -705,7 +705,7 @@ public class VirtuosoConnection implements Connection
 			       "but processing character escapes also disabled",
 			       VirtuosoException.MISCERROR);
 			 //System.err.println ("version=[" + version + " ver=" + version.substring (6, 10));
-			 //if ((new Integer (version.substring (6, 10))).intValue() > 2143)
+			 //if ((Integer.valueOf(version.substring (6, 10))).intValue() > 2143)
 			 //  utf8_execs = true;
 
 			 timezoneless_datetimes = (int) cdef_param (client_defaults, "SQL_TIMEZONELESS_DATETIMES", 0);
@@ -864,7 +864,7 @@ public class VirtuosoConnection implements Connection
      // Create a VirtuosoFuture instance
      fut = new VirtuosoFuture(this,rpcname,args,this_req_no, timeout);
      // Set the request id and put it into the hash table
-     futures.put(new Integer(this_req_no),fut);
+     futures.put(Integer.valueOf(this_req_no),fut);
      return fut;
    }
 
@@ -885,7 +885,7 @@ public class VirtuosoConnection implements Connection
    protected void removeFuture(VirtuosoFuture fut)
    {
      if (futures != null)
-       futures.remove(new Integer(fut.hashCode()));
+       futures.remove(Integer.valueOf(fut.hashCode()));
    }
 
    /**
@@ -942,7 +942,7 @@ public class VirtuosoConnection implements Connection
 	   return false;
 	 // Then put the message into the corresponding future queue
 	 //System.out.println("---------------> read_reqest for "+((Number)result.elementAt(1)).intValue());
-	 VirtuosoFuture fut = (VirtuosoFuture)futures.get(new Integer(((Number)result.elementAt(1)).intValue()));
+	 VirtuosoFuture fut = (VirtuosoFuture)futures.get(Integer.valueOf(((Number)result.elementAt(1)).intValue()));
 	 if(fut == null)
 	   return false;
 	 fut.putResult(result.elementAt(2));
@@ -1006,7 +1006,7 @@ public class VirtuosoConnection implements Connection
      {
        try
 	 {
-	   return (new Integer (version.substring (6, 10))).intValue();
+	   return (Integer.valueOf(version.substring (6, 10))).intValue();
 	 }
        catch (Exception e)
 	 {
@@ -1108,7 +1108,7 @@ public class VirtuosoConnection implements Connection
       {
 	// RPC transaction
 	Object[] args = new Object[2];
-	args[0] = new Long(VirtuosoTypes.SQL_COMMIT);
+	args[0] = Long.valueOf(VirtuosoTypes.SQL_COMMIT);
 	args[1] = null;
 	VirtuosoFuture fut = getFuture(VirtuosoFuture.transaction,args, this.timeout);
 	openlink.util.Vector trsres = fut.nextResult();
@@ -1289,7 +1289,7 @@ public class VirtuosoConnection implements Connection
       {
          // RPC transaction
          Object[] args = new Object[2];
-         args[0] = new Long(VirtuosoTypes.SQL_ROLLBACK);
+         args[0] = Long.valueOf(VirtuosoTypes.SQL_ROLLBACK);
          args[1] = null;
          VirtuosoFuture fut = getFuture(VirtuosoFuture.transaction,args, this.timeout);
          openlink.util.Vector trsres = fut.nextResult();

--- a/libsrc/JDBCDriverType4/virtuoso/jdbc/VirtuosoExplicitString.java
+++ b/libsrc/JDBCDriverType4/virtuoso/jdbc/VirtuosoExplicitString.java
@@ -183,9 +183,9 @@ public class VirtuosoExplicitString
        {
         for (int i = 0; i < str.length(); i++)
 	  {
-	    Character ch = new Character (str.charAt(i));
+	    Character ch = Character.valueOf (str.charAt(i));
 	    Byte b;
-	    b = (Byte)(charset_ht != null ? charset_ht.get (ch) : new Byte ((byte) (ch.charValue())));
+	    b = (Byte)(charset_ht != null ? charset_ht.get (ch) : Byte.valueOf ((byte) (ch.charValue())));
 	    if (b == null)
 	      {
 	        bytes[i] = (byte) '?';
@@ -218,7 +218,7 @@ public class VirtuosoExplicitString
 
 	  if (ht != null)
 	    {
-	      Character ch = new Character (curr);
+	      Character ch = Character.valueOf (curr);
 	      b = (Byte)ht.get (ch);
 	      if (b == null)
 		{

--- a/libsrc/JDBCDriverType4/virtuoso/jdbc/VirtuosoFuture.java
+++ b/libsrc/JDBCDriverType4/virtuoso/jdbc/VirtuosoFuture.java
@@ -116,8 +116,8 @@ class VirtuosoFuture
          vector[4] = null;
       vector[3] = rpcname;
       vector[2] = null;
-      vector[1] = new Integer(req_no);
-      vector[0] = new Integer(VirtuosoTypes.DA_FUTURE_REQUEST);
+      vector[1] = Integer.valueOf(req_no);
+      vector[0] = Integer.valueOf(VirtuosoTypes.DA_FUTURE_REQUEST);
       // Serialize data and flush the stream
       connection.write_object(new openlink.util.Vector(vector));
    }

--- a/libsrc/JDBCDriverType4/virtuoso/jdbc/VirtuosoInputStream.java
+++ b/libsrc/JDBCDriverType4/virtuoso/jdbc/VirtuosoInputStream.java
@@ -162,7 +162,7 @@ class VirtuosoInputStream extends BufferedInputStream
              case VirtuosoTypes.DV_NULL:
                    {
                      //System.out.println("DV_NULL");
-                     return new Short((short)0); //null; because off absence of TAG_BOX in O12
+                     return Short.valueOf((short)0); //null; because off absence of TAG_BOX in O12
                    }
              case VirtuosoTypes.DV_DB_NULL:
                    {
@@ -188,7 +188,7 @@ class VirtuosoInputStream extends BufferedInputStream
                      int n = readint();
                      Object[] array = new Object[(int)n];
                      for(int i = 0;i < n;i++)
-                       array[i] = new Long(readlongint());
+                       array[i] = Long.valueOf(readlongint());
                      res = new VectorOfLong(array);
                      //System.out.print("DV_ARRAY_OF_LONG");
 		     //System.out.println (res.toString());
@@ -201,7 +201,7 @@ class VirtuosoInputStream extends BufferedInputStream
                      int n = readint();
                      Object[] array = new Object[(int)n];
                      for(int i = 0;i < n;i++)
-                       array[i] = new Long(readlongint());
+                       array[i] = Long.valueOf(readlongint());
                      res = new VectorOfLong(array);
                      //System.out.print("DV_ARRAY_OF_LONG_PACKED: ");
 		     //System.out.println (res.toString());
@@ -213,7 +213,7 @@ class VirtuosoInputStream extends BufferedInputStream
                      int n = readint();
                      Object[] array = new Object[(int)n];
                      for(int i = 0;i < n;i++)
-                       array[i] = new Double(readdouble());
+                       array[i] = Double.valueOf(readdouble());
                      res = new VectorOfDouble(array);
                      //System.out.print("DV_ARRAY_OF_DOUBLE: ");
 		     //System.out.println (res.toString());
@@ -225,7 +225,7 @@ class VirtuosoInputStream extends BufferedInputStream
                      int n = readint();
                      Object[] array = new Object[(int)n];
                      for(int i = 0;i < n;i++)
-                       array[i] = new Float(readfloat());
+                       array[i] = Float.valueOf(readfloat());
                      res = new VectorOfFloat(array);
                      //System.out.print("DV_ARRAY_OF_FLOAT: ");
 		     //System.out.println (res.toString());
@@ -329,7 +329,7 @@ class VirtuosoInputStream extends BufferedInputStream
              case VirtuosoTypes.DV_SINGLE_FLOAT:
                    {
                      //System.out.println("DV_SINGLE_FLOAT");
-                     res = new Float(readfloat());
+                     res = Float.valueOf(readfloat());
                      //System.out.print("DV_SINGLE_FLOAT: ");
 		     //System.out.println (res.toString());
                      return res;
@@ -337,7 +337,7 @@ class VirtuosoInputStream extends BufferedInputStream
              case VirtuosoTypes.DV_DOUBLE_FLOAT:
                    {
                      //System.out.println("DV_DOUBLE_FLOAT");
-                     res = new Double(readdouble());
+                     res = Double.valueOf(readdouble());
                      //System.out.print("DV_DOUBLE_FLOAT: ");
 		     //System.out.println (res.toString());
                      return res;
@@ -348,7 +348,7 @@ class VirtuosoInputStream extends BufferedInputStream
 		     int ret = readshortint();
 		     if (ret > 127)
 		       ret = ret - 256;
-                     res = new Short((short)ret);
+                     res = Short.valueOf((short)ret);
                      //System.out.print("DV_SHORT_INT: ");
 		     //System.out.println (res.toString());
                      return res;
@@ -356,7 +356,7 @@ class VirtuosoInputStream extends BufferedInputStream
              case VirtuosoTypes.DV_LONG_INT:
                    {
                      //System.out.println("DV_LONG_INT");
-                     res = new Integer(readlongint());
+                     res = Integer.valueOf(readlongint());
                      //System.out.print("DV_LONG_INT: ");
 		     //System.out.println (res.toString());
                      return res;
@@ -439,13 +439,13 @@ class VirtuosoInputStream extends BufferedInputStream
                    }
              case VirtuosoTypes.DV_IRI_ID:
                    {
-                     res = new Integer(readlongint());
+                     res = Integer.valueOf(readlongint());
                      return res;
                    }
              case VirtuosoTypes.DV_IRI_ID_8:
              case VirtuosoTypes.DV_INT64:
                    {
-                     res = new Long(readlong());
+                     res = Long.valueOf(readlong());
                      return res;
                    }
 	     case VirtuosoTypes.DV_RDF:

--- a/libsrc/JDBCDriverType4/virtuoso/jdbc/VirtuosoPreparedStatement.java
+++ b/libsrc/JDBCDriverType4/virtuoso/jdbc/VirtuosoPreparedStatement.java
@@ -87,7 +87,7 @@ public class VirtuosoPreparedStatement extends VirtuosoStatement implements Prep
 	      Object[] args = new Object[4];
 	      args[0] = (statid == null) ? statid = new String("ps" + connection.hashCode() + (req_no++)) : statid;
 	      args[1] = connection.escapeSQL(sql);
-	      args[2] = new Long(0);
+	      args[2] = Long.valueOf(0);
 	      args[3] = getStmtOpts();
 	      // Create a future
 	      future = connection.getFuture(VirtuosoFuture.prepare,args, this.rpc_timeout);
@@ -362,7 +362,7 @@ public class VirtuosoPreparedStatement extends VirtuosoStatement implements Prep
 	     // Build the args array
 	     Object[] args = new Object[2];
 	     args[0] = statid;
-	     args[1] = new Long(VirtuosoTypes.STAT_DROP);
+	     args[1] = Long.valueOf(VirtuosoTypes.STAT_DROP);
 	     // Create and get a future for this
 	     future = connection.getFuture(VirtuosoFuture.close,args, this.rpc_timeout);
 	     // Read the answer
@@ -612,7 +612,7 @@ public class VirtuosoPreparedStatement extends VirtuosoStatement implements Prep
       // Check parameters
       if(parameterIndex < 1 || parameterIndex > parameters.capacity())
          throw new VirtuosoException("Index " + parameterIndex + " is not 1<n<" + parameters.capacity(),VirtuosoException.BADPARAM);
-      objparams.setElementAt(new Boolean(x),parameterIndex - 1);
+      objparams.setElementAt(Boolean.valueOf(x),parameterIndex - 1);
    }
 
    /**
@@ -629,7 +629,7 @@ public class VirtuosoPreparedStatement extends VirtuosoStatement implements Prep
       // Check parameters
       if(parameterIndex < 1 || parameterIndex > parameters.capacity())
          throw new VirtuosoException("Index " + parameterIndex + " is not 1<n<" + parameters.capacity(),VirtuosoException.BADPARAM);
-      objparams.setElementAt(new Byte(x),parameterIndex - 1);
+      objparams.setElementAt(Byte.valueOf(x),parameterIndex - 1);
    }
 
    /**
@@ -686,7 +686,7 @@ public class VirtuosoPreparedStatement extends VirtuosoStatement implements Prep
       // Check parameters
       if(parameterIndex < 1 || parameterIndex > parameters.capacity())
          throw new VirtuosoException("Index " + parameterIndex + " is not 1<n<" + parameters.capacity(),VirtuosoException.BADPARAM);
-      objparams.setElementAt(new Double(x),parameterIndex - 1);
+      objparams.setElementAt(Double.valueOf(x),parameterIndex - 1);
    }
 
    /**
@@ -703,7 +703,7 @@ public class VirtuosoPreparedStatement extends VirtuosoStatement implements Prep
       // Check parameters
       if(parameterIndex < 1 || parameterIndex > parameters.capacity())
          throw new VirtuosoException("Index " + parameterIndex + " is not 1<n<" + parameters.capacity(),VirtuosoException.BADPARAM);
-      objparams.setElementAt(new Float(x),parameterIndex - 1);
+      objparams.setElementAt(Float.valueOf(x),parameterIndex - 1);
    }
 
    /**
@@ -720,7 +720,7 @@ public class VirtuosoPreparedStatement extends VirtuosoStatement implements Prep
       // Check parameters
       if(parameterIndex < 1 || parameterIndex > parameters.capacity())
          throw new VirtuosoException("Index " + parameterIndex + " is not 1<n<" + parameters.capacity(),VirtuosoException.BADPARAM);
-      objparams.setElementAt(new Integer(x),parameterIndex - 1);
+      objparams.setElementAt(Integer.valueOf(x),parameterIndex - 1);
    }
 
    /**
@@ -737,7 +737,7 @@ public class VirtuosoPreparedStatement extends VirtuosoStatement implements Prep
       // Check parameters
       if(parameterIndex < 1 || parameterIndex > parameters.capacity())
          throw new VirtuosoException("Index " + parameterIndex + " is not 1<n<" + parameters.capacity(),VirtuosoException.BADPARAM);
-      objparams.setElementAt(new Long(x),parameterIndex - 1);
+      objparams.setElementAt(Long.valueOf(x),parameterIndex - 1);
    }
 
    /**
@@ -865,7 +865,7 @@ public class VirtuosoPreparedStatement extends VirtuosoStatement implements Prep
       // Check parameters
       if(parameterIndex < 1 || parameterIndex > parameters.capacity())
          throw new VirtuosoException("Index " + parameterIndex + " is not 1<n<" + parameters.capacity(),VirtuosoException.BADPARAM);
-      objparams.setElementAt(new Short(x),parameterIndex - 1);
+      objparams.setElementAt(Short.valueOf(x),parameterIndex - 1);
    }
 
    /**

--- a/libsrc/JDBCDriverType4/virtuoso/jdbc/VirtuosoRdfBox.java
+++ b/libsrc/JDBCDriverType4/virtuoso/jdbc/VirtuosoRdfBox.java
@@ -209,7 +209,7 @@ public class VirtuosoRdfBox implements RdfBox
     private String _getType ()
     {
       ensureTypeHash ();
-      return (String) this.connection.rdf_type_hash.get (new Integer (this.rb_type));
+      return (String) this.connection.rdf_type_hash.get (Integer.valueOf (this.rb_type));
     }
 
     public String getType ()
@@ -230,7 +230,7 @@ public class VirtuosoRdfBox implements RdfBox
     private String _getLang ()
     {
       ensureLangHash ();
-      return (String) this.connection.rdf_lang_hash.get (new Integer (this.rb_lang));
+      return (String) this.connection.rdf_lang_hash.get (Integer.valueOf (this.rb_lang));
     }
 
     public String getLang ()

--- a/libsrc/JDBCDriverType4/virtuoso/jdbc/VirtuosoResultSet.java
+++ b/libsrc/JDBCDriverType4/virtuoso/jdbc/VirtuosoResultSet.java
@@ -290,7 +290,7 @@ public class VirtuosoResultSet implements ResultSet
 	    // Fill the statement id,the operation, and the beginning line
 	    args[0] = statement.statid;
 	    // the future number
-	    args[1] = new Long(statement.future.hashCode());
+	    args[1] = Long.valueOf(statement.future.hashCode());
 	    // Send the RPC message
 	    statement.connection.removeFuture(statement.connection.getFuture(
 		  VirtuosoFuture.fetch,args, statement.rpc_timeout));
@@ -320,11 +320,11 @@ public class VirtuosoResultSet implements ResultSet
 	    Object[] args = new Object[6];
 	    // Fill the statement id,the operation, and the beginning line
 	    args[0] = statement.statid;
-	    args[1] = new Long(op);
-	    args[2] = new Long(firstline);
-	    args[3] = new Long(nbline);
+	    args[1] = Long.valueOf(op);
+	    args[2] = Long.valueOf(firstline);
+	    args[3] = Long.valueOf(nbline);
 	    // Fill the autocommit mode
-	    args[4] = new Long((statement.connection.getAutoCommit()) ? 1 : 0);
+	    args[4] = Long.valueOf((statement.connection.getAutoCommit()) ? 1 : 0);
 	    // Fill the bookmark (never used for the moment in JDBC)
 	    args[5] = null;
 	    // Send the RPC message
@@ -2707,7 +2707,7 @@ public class VirtuosoResultSet implements ResultSet
          if(!(currentRow < 1 || currentRow > rows.size()))
             ((VirtuosoRow)(rows.elementAt(currentRow - 1))).getContent(row);
       }
-      row[columnIndex - 1] = new Boolean(x);
+      row[columnIndex - 1] = Boolean.valueOf(x);
    }
 
    /**
@@ -2733,7 +2733,7 @@ public class VirtuosoResultSet implements ResultSet
          if(!(currentRow < 1 || currentRow > rows.size()))
             ((VirtuosoRow)(rows.elementAt(currentRow - 1))).getContent(row);
       }
-      row[columnIndex - 1] = new Byte(x);
+      row[columnIndex - 1] = Byte.valueOf(x);
    }
 
    /**
@@ -2759,7 +2759,7 @@ public class VirtuosoResultSet implements ResultSet
          if(!(currentRow < 1 || currentRow > rows.size()))
             ((VirtuosoRow)(rows.elementAt(currentRow - 1))).getContent(row);
       }
-      row[columnIndex - 1] = new Short(x);
+      row[columnIndex - 1] = Short.valueOf(x);
    }
 
    /**
@@ -2785,7 +2785,7 @@ public class VirtuosoResultSet implements ResultSet
          if(!(currentRow < 1 || currentRow > rows.size()))
             ((VirtuosoRow)(rows.elementAt(currentRow - 1))).getContent(row);
       }
-      row[columnIndex - 1] = new Integer(x);
+      row[columnIndex - 1] = Integer.valueOf(x);
    }
 
    /**
@@ -2811,7 +2811,7 @@ public class VirtuosoResultSet implements ResultSet
          if(!(currentRow < 1 || currentRow > rows.size()))
             ((VirtuosoRow)(rows.elementAt(currentRow - 1))).getContent(row);
       }
-      row[columnIndex - 1] = new Long(x);
+      row[columnIndex - 1] = Long.valueOf(x);
    }
 
    /**
@@ -2837,7 +2837,7 @@ public class VirtuosoResultSet implements ResultSet
          if(!(currentRow < 1 || currentRow > rows.size()))
             ((VirtuosoRow)(rows.elementAt(currentRow - 1))).getContent(row);
       }
-      row[columnIndex - 1] = new Float(x);
+      row[columnIndex - 1] = Float.valueOf(x);
    }
 
    /**
@@ -2863,7 +2863,7 @@ public class VirtuosoResultSet implements ResultSet
          if(!(currentRow < 1 || currentRow > rows.size()))
             ((VirtuosoRow)(rows.elementAt(currentRow - 1))).getContent(row);
       }
-      row[columnIndex - 1] = new Double(x);
+      row[columnIndex - 1] = Double.valueOf(x);
    }
 
    /**

--- a/libsrc/JDBCDriverType4/virtuoso/jdbc/VirtuosoResultSetMetaData.java
+++ b/libsrc/JDBCDriverType4/virtuoso/jdbc/VirtuosoResultSetMetaData.java
@@ -62,7 +62,7 @@ public class VirtuosoResultSetMetaData implements ResultSetMetaData
       {
          // Create the new column
          VirtuosoColumn col = new VirtuosoColumn(columns[i], dtps[i], conn);
-         hcolumns.put(col,new Integer(i));
+         hcolumns.put(col,Integer.valueOf(i));
          columnsMetaData.insertElementAt(col,i);
       }
    }
@@ -87,7 +87,7 @@ public class VirtuosoResultSetMetaData implements ResultSetMetaData
          VirtuosoColumn col =
 	     new VirtuosoColumn((openlink.util.Vector)((openlink.util.Vector)vect).elementAt(i),
 		 conn);
-         hcolumns.put(col,new Integer(i));
+         hcolumns.put(col,Integer.valueOf(i));
          columnsMetaData.insertElementAt(col,i);
       }
    }

--- a/libsrc/JDBCDriverType4/virtuoso/jdbc/VirtuosoStatement.java
+++ b/libsrc/JDBCDriverType4/virtuoso/jdbc/VirtuosoStatement.java
@@ -154,7 +154,7 @@ public class VirtuosoStatement implements Statement
    protected VectorOfLong getStmtOpts () throws VirtuosoException
      {
        // Set the concurrency type
-       Long[] arrLong = Long.valueOf[11];
+       Long[] arrLong = new Long [11];
        if (connection.isReadOnly ()) {
          arrLong[0] = Long.valueOf (VirtuosoTypes.SQL_CONCUR_ROWVER);
        }

--- a/libsrc/JDBCDriverType4/virtuoso/jdbc/VirtuosoStatement.java
+++ b/libsrc/JDBCDriverType4/virtuoso/jdbc/VirtuosoStatement.java
@@ -154,56 +154,56 @@ public class VirtuosoStatement implements Statement
    protected VectorOfLong getStmtOpts () throws VirtuosoException
      {
        // Set the concurrency type
-       Long[] arrLong = new Long[11];
+       Long[] arrLong = Long.valueOf[11];
        if (connection.isReadOnly ()) {
-         arrLong[0] = new Long (VirtuosoTypes.SQL_CONCUR_ROWVER);
+         arrLong[0] = Long.valueOf (VirtuosoTypes.SQL_CONCUR_ROWVER);
        }
        else {
          if (concurrency == VirtuosoResultSet.CONCUR_VALUES)
-           arrLong[0] = new Long(VirtuosoTypes.SQL_CONCUR_VALUES);
+           arrLong[0] = Long.valueOf(VirtuosoTypes.SQL_CONCUR_VALUES);
        else
-	 arrLong[0] = new Long(concurrency == VirtuosoResultSet.CONCUR_READ_ONLY ?
+	 arrLong[0] = Long.valueOf(concurrency == VirtuosoResultSet.CONCUR_READ_ONLY ?
 		VirtuosoTypes.SQL_CONCUR_READ_ONLY : VirtuosoTypes.SQL_CONCUR_LOCK);
        }
-       arrLong[1] = new Long(0);
-       arrLong[2] = new Long(maxRows);
+       arrLong[1] = Long.valueOf(0);
+       arrLong[2] = Long.valueOf(maxRows);
        if (connection.getGlobalTransaction()) {
            VirtuosoXAConnection xac = (VirtuosoXAConnection) connection.xa_connection;
 	   if (VirtuosoFuture.rpc_log != null)
 	   {
 		   VirtuosoFuture.rpc_log.println ("VirtuosoStatement.getStmtOpts () xa_res=" + xac.getVirtuosoXAResource().hashCode() + " :" + hashCode());
 	   }
-           arrLong[3] = new Long(xac.getVirtuosoXAResource().txn_timeout * 1000);
+           arrLong[3] = Long.valueOf(xac.getVirtuosoXAResource().txn_timeout * 1000);
        } else {
-           arrLong[3] = new Long(txn_timeout * 1000);
+           arrLong[3] = Long.valueOf(txn_timeout * 1000);
        }
      if (VirtuosoFuture.rpc_log != null)
        {
 	     VirtuosoFuture.rpc_log.println ("VirtuosoStatement.getStmtOpts (txn_timeout=" + arrLong[3] + ") (con=" + connection.hashCode() + ") :" + hashCode());
        }
-       arrLong[4] = new Long(prefetch);
+       arrLong[4] = Long.valueOf(prefetch);
        // Set the autocommit
-       arrLong[5] = new Long((connection.getAutoCommit()) ? 1 : 0);
-       arrLong[6] = new Long (rpc_timeout);
+       arrLong[5] = Long.valueOf((connection.getAutoCommit()) ? 1 : 0);
+       arrLong[6] = Long.valueOf (rpc_timeout);
        // Set the cursor type
        switch(type)
 	 {
 	   case VirtuosoResultSet.TYPE_FORWARD_ONLY:
-	       arrLong[7] = new Long(VirtuosoTypes.SQL_CURSOR_FORWARD_ONLY);
+	       arrLong[7] = Long.valueOf(VirtuosoTypes.SQL_CURSOR_FORWARD_ONLY);
 	       break;
 	   case VirtuosoResultSet.TYPE_SCROLL_SENSITIVE:
-	       arrLong[7] = new Long(VirtuosoTypes.SQL_CURSOR_DYNAMIC);
+	       arrLong[7] = Long.valueOf(VirtuosoTypes.SQL_CURSOR_DYNAMIC);
 	       break;
 	   case VirtuosoResultSet.TYPE_SCROLL_INSENSITIVE:
-	       arrLong[7] = new Long(VirtuosoTypes.SQL_CURSOR_STATIC);
+	       arrLong[7] = Long.valueOf(VirtuosoTypes.SQL_CURSOR_STATIC);
 	       break;
 	 }
        ;
        // Set keyset size and bookmark
-       arrLong[8] = new Long(0);
-       arrLong[9] = new Long(1);
+       arrLong[8] = Long.valueOf(0);
+       arrLong[9] = Long.valueOf(1);
        // Set the isolation mode
-       arrLong[10] = new Long(connection.getTransactionIsolation());
+       arrLong[10] = Long.valueOf(connection.getTransactionIsolation());
        // Put the options array in the args array
        return new VectorOfLong(arrLong);
      }
@@ -336,7 +336,7 @@ public class VirtuosoStatement implements Statement
 	     // Build the args array
 	     Object[] args = new Object[2];
 	     args[0] = statid;
-	     args[1] = close_stmt ? new Long(VirtuosoTypes.STAT_DROP): new Long(VirtuosoTypes.STAT_CLOSE);
+	     args[1] = close_stmt ? Long.valueOf(VirtuosoTypes.STAT_DROP): Long.valueOf(VirtuosoTypes.STAT_CLOSE);
 	     // Create and get a future for this
 	     future = connection.getFuture(VirtuosoFuture.close,args, this.rpc_timeout);
 	     // Read the answer
@@ -505,7 +505,7 @@ public class VirtuosoStatement implements Statement
 		   // Send the fetch query
 		   Object[] args = new Object[2];
 		   args[0] = statid;
-		   args[1] = new Long(future.hashCode());
+		   args[1] = Long.valueOf(future.hashCode());
 		   future.send_message(VirtuosoFuture.fetch,args);
 		   // ReArm the process
 		   vresultSet.getMoreResults(false);

--- a/libsrc/JDBCDriverType4/virtuoso/jdbc/VirtuosoTypes.java
+++ b/libsrc/JDBCDriverType4/virtuoso/jdbc/VirtuosoTypes.java
@@ -448,7 +448,7 @@ class VirtuosoTypes
      if (x == null)
        return x;
      if (x instanceof java.lang.Boolean)
-       x = new Integer (((Boolean)x).booleanValue() ? 1 : 0);
+       x = Integer.valueOf (((Boolean)x).booleanValue() ? 1 : 0);
 
      switch (targetSqlType)
        {
@@ -550,9 +550,9 @@ class VirtuosoTypes
 
           case Types.BIGINT:
               if (x instanceof java.math.BigDecimal || x instanceof java.lang.String)
-                return new Long(x.toString());
+                return Long.parseLong(x.toString());
               else if (x instanceof java.lang.Number)
-                return new Long(((Number)x).longValue());
+                return Long.valueOf(((Number)x).longValue());
 	      break;
 
           case Types.FLOAT:
@@ -560,26 +560,26 @@ class VirtuosoTypes
               if (x instanceof java.lang.Double)
                 return x;
               else if (x instanceof java.lang.Number)
-                return new Double (((Number)x).doubleValue());
+                return Double.valueOf (((Number)x).doubleValue());
               else if (x instanceof java.lang.String)
-                return new Double ((String) x);
+                return Double.parseDouble((String) x);
 	      break;
           case Types.INTEGER:
               if (x instanceof java.lang.Integer)
                 return x;
               else if (x instanceof java.lang.Number)
-                return new Integer (((Number)x).intValue());
+                return Integer.valueOf (((Number)x).intValue());
               else if (x instanceof java.lang.String)
-                return new Integer ((String) x);
+                return Integer.valueOf ((String) x);
 	      break;
 
           case Types.REAL:
               if (x instanceof java.lang.Float)
                 return x;
               else if (x instanceof java.lang.Number)
-                return new Float (((Number)x).floatValue());
+                return Float.valueOf(((Number)x).floatValue());
               else if (x instanceof java.lang.String)
-                return new Float ((String) x);
+                return Float.parseFloat((String) x);
 	      break;
 
           case Types.SMALLINT:
@@ -589,9 +589,9 @@ class VirtuosoTypes
               if (x instanceof java.lang.Short)
                 return x;
               else if (x instanceof java.lang.String)
-                return new Short ((String) x);
+                return Short.parseShort((String) x);
               else if (x instanceof java.lang.Number)
-                return new Short (((Number)x).shortValue());
+                return Short.valueOf (((Number)x).shortValue());
 	      break;
 
 	  case Types.ARRAY:

--- a/libsrc/JDBCDriverType4/virtuoso/jdbc/VirtuosoXAResource.java
+++ b/libsrc/JDBCDriverType4/virtuoso/jdbc/VirtuosoXAResource.java
@@ -382,7 +382,7 @@ public class VirtuosoXAResource implements XAResource
     private void rpc(VirtuosoConnection connection, int action, Object encodedXid)
         throws XAException {
         Object[] args = new Object[2];
-        args[0] = new Integer(action);
+        args[0] = Integer.valueOf(action);
         args[1] = encodedXid;
 
         try {


### PR DESCRIPTION
They are all deprecated.

`new Long(1)` should be `Long.valueOf(1)` of course auto boxing works in most places but I think the patch is easier to review this way.