### PR TITLE
Display datatype links like other links

### DIFF
--- a/binsrc/fct/rdfdesc/description.sql
+++ b/binsrc/fct/rdfdesc/description.sql
@@ -854,7 +854,12 @@ create procedure b3s_label (in _S any, in langs any, in lbl_order_pref_id int :=
 
 create procedure b3s_xsd_link (in dt varchar)
 {
-  return sprintf ('<a href="%s">%s</a>', dt, b3s_uri_curie(dt));
+  declare p_prefix, url any;
+  p_prefix := b3s_label (dt, null);
+  if (not length (p_prefix))
+    p_prefix := b3s_uri_curie (dt);
+  url := b3s_http_url (dt, null, null, 0);
+  return sprintf ('<a href="%s">%s</a>', url, p_prefix);
 }
 ;
 


### PR DESCRIPTION
Datatype links are the only links that are not displayed with a label taken from the database, and not linking to a `/describe` page first. This changes that so that datatype links (custom datatypes in particular) are processed akin to normal property links.