### PR TITLE
GH-965 Finalizers should be minimal

### DIFF
--- a/binsrc/rdf4j/virtuoso_driver/VirtuosoRepositoryConnection.java
+++ b/binsrc/rdf4j/virtuoso_driver/VirtuosoRepositoryConnection.java
@@ -3387,15 +3387,6 @@ public class VirtuosoRepositoryConnection implements RepositoryConnection {
             v_finished = true;
         }
 
-        protected void finalize() throws Throwable
-        {
-            super.finalize();
-            if (!v_finished)
-                try {
-                    close();
-                } catch (Exception e) {}
-        }
-
         protected void moveForward() throws X
         {
             try
@@ -3524,7 +3515,8 @@ public class VirtuosoRepositoryConnection implements RepositoryConnection {
                     ((QueryBindingSet)v_row).setBinding(col, v);
                 }
             }
-        }
+        }        
+        
     }
 
 

--- a/libsrc/JDBCDriverType4/virtuoso/jdbc/VirtuosoResultSet.java
+++ b/libsrc/JDBCDriverType4/virtuoso/jdbc/VirtuosoResultSet.java
@@ -687,14 +687,6 @@ public class VirtuosoResultSet implements ResultSet
       }
    }
 
-   /**
-    * Method runs when the garbage collector want to erase the object
-    */
-   public void finalize() throws Throwable
-   {
-      close();
-   }
-
    void fixReturnedData(openlink.util.Vector data)
    {
      if (data == null)


### PR DESCRIPTION
Especially in locking and should not be there just to
"null" a field.

Finalizers on object a should not call code called by finalizers of
object b.