### PR TITLE
docs: fix XAnyNormalization documentation caption

### DIFF
--- a/docsrc/xmlsource/server.xml
+++ b/docsrc/xmlsource/server.xml
@@ -1800,7 +1800,7 @@ impractical in all cases.
                   	
                   	<listitem id="ini_I18N_XAnyNormalization">
                       <formalpara>
-                        <title>WideFileNames = 1/2/3/0</title>
+                        <title>XAnyNormalization = 1/2/3/0</title>
                         <para>0: default value. It means not to normalize anything, so for ex. 
                         	"José" and "Jose" are two distinct words.</para>
                         <para>1: Any pair of base char and combinig char (NSM, non-spacing


### PR DESCRIPTION
It looks like it was accidentally documented as `WideFileNames`
(which is the next documented option)