### PR TITLE
additional need for doc update revealed by docfix of #1083

### DIFF
--- a/debian/README.Debian
+++ b/debian/README.Debian
@@ -54,7 +54,7 @@ the GUI in Administration Interface at http://127.0.0.1:8890/conductor/ under
 "WebDAV Administration / WebDAV services / Users Administrator" or use the SQL
 statement:
 
-update WS.WS.SYS_DAV_USER set U_PASSWORD='<new password>'
+update WS.WS.SYS_DAV_USER set U_PWD='<new password>'
 where U_NAME='<username>'
     
  -- Obey Arthur Liu <arthur@milliways.fr>  Tue, 22 Dec 2009 16:49:42 +0100


### PR DESCRIPTION
commit 76c16f97b312db3832d66f4939cfc543fec40c2e fixed #1083, but left other cleanup to be made

I cannot promise that there is no more related cleanup to do --  
* https://github.com/openlink/virtuoso-opensource/search?q=U_PASSWORD
* https://github.com/openlinksoftware/documentation/search?q=U_PASSWORD