### PR TITLE
Add 'subdir-objects' to INIT_AUTOMAKE.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,7 +57,7 @@ dnl	AM_INIT_AUTOMAKE([1.7])
 dnl	AM_INIT_AUTOMAKE([1.8])
 dnl	AM_INIT_AUTOMAKE([1.9 tar-ustar])
 dnl
-AM_INIT_AUTOMAKE([1.9 tar-ustar])
+AM_INIT_AUTOMAKE([1.9 tar-ustar subdir-objects])
 
 AM_MAINTAINER_MODE
 


### PR DESCRIPTION
While `SUBDIRS` is used to build Virtuoso, the `'subdir-objects'` initialization option is missing in `INIT_AUTOMAKE`.  This commit fixes that.

* configure.ac: Add `'subdir-objects'` to `INIT_AUTOMAKE`.