### PR TITLE
Stabilize JSON-LD context loading

### DIFF
--- a/binsrc/tests/suite/tjsonld.sql
+++ b/binsrc/tests/suite/tjsonld.sql
@@ -6,6 +6,8 @@ create procedure jldfile(in f varchar)
 
 DB.DBA.SYS_CACHED_RESOURCE_ADD ('https://www.w3.org/ns/activitystreams', '', jldfile ('activitystreams.jsonld'), curutcdatetime(), 'Activity Streams Vocabulary');
 DB.DBA.SYS_CACHED_RESOURCE_ADD ('http://www.w3.org/ns/activitystreams', '', jldfile ('activitystreams.jsonld'), curutcdatetime(), 'Activity Streams Vocabulary');
+DB.DBA.SYS_CACHED_RESOURCE_ADD ('https://www.w3.org/ns/activitystreams#', '', jldfile ('activitystreams.jsonld'), curutcdatetime(), 'Activity Streams Vocabulary');
+DB.DBA.SYS_CACHED_RESOURCE_ADD ('http://www.w3.org/ns/activitystreams#', '', jldfile ('activitystreams.jsonld'), curutcdatetime(), 'Activity Streams Vocabulary');
 DB.DBA.SYS_CACHED_RESOURCE_ADD ('https://w3id.org/security/v1', '', jldfile ('security-v1.jsonld'), curutcdatetime(), 'Security Vocabulary');
 DB.DBA.SYS_CACHED_RESOURCE_ADD ('http://schema.org/', '', jldfile ('jsonldcontext.json'), curutcdatetime(), 'Schema.org Vocabulary');
 DB.DBA.SYS_CACHED_RESOURCE_ADD ('https://json-ld.org/contexts/person.jsonld', '', jldfile ('person.jsonld'), curutcdatetime(), 'Person Vocabulary');
@@ -71,7 +73,10 @@ create procedure jacts_run (in tn varchar, in f int := 0)
   };
   jacts_load_ttl (tn);
   sparql clear graph ?:graph_iid;
-  DB.DBA.RDF_LOAD_JSON_LD (file_to_string (jacts_path (tn)), '', jacts_graph(tn));
+  -- ActivityStreams cases depend on an external JSON-LD context.  Keep the
+  -- parser and its context resolution in the caller transaction so a test
+  -- cannot race the vectorized loader's worker queue while comparing graphs.
+  DB.DBA.RDF_LOAD_JSON_LD (file_to_string (jacts_path (tn)), '', jacts_graph(tn), 0, 0, 1);
   commit work;
   return 'OK';
 }
@@ -303,4 +308,3 @@ jacts_dump_results();
 ECHO BOTH $IF $EQU $STATE OK "PASSED" "*** FAILED";
 SET ARGV[$LIF] $+ $ARGV[$LIF] 1;
 ECHO BOTH ": JSON-LD results check STATE=" $STATE " MESSAGE=" $MESSAGE "\n";
-

--- a/libsrc/Wi/bif_json.c
+++ b/libsrc/Wi/bif_json.c
@@ -458,7 +458,8 @@ jsonld_frame_pop (jsonp_t *jsonp_arg)
 /*
    tries to get vocab from cache, the calling code is in charge to set XML_URI_GET_ACCEPT connection property
    as well as HTTP_CLI_TIMEOUT sec
-   if can't find or get from cache fails silently, if find something parse in same MP and pushe in the CTX's HT maps.
+   if can't find or get from cache fails, retry once and then propagate the
+   error instead of silently parsing terms without the requested context.
    Note parsing uses JMODE_LD_CTX which do not load anything in RDF store, only fill the current cache,
    another note, the CTX nesting is not performed because is import
  */
@@ -473,10 +474,16 @@ jsonld_context_uri_get (jsonp_t * jsonp_arg, caddr_t uri, id_hash_t *ht)
   jsonld_ctx_t jctx;
   yyscan_t scanner;
 
-  if (err) /* not loaded, http error or something */
+  if (err) /* retry transient cache/HTTP failures once */
     {
       dk_free_tree (err);
-      return;
+      err = NULL;
+      content = xml_uri_get (qi, &err, NULL, jsonp_arg->base_uri, uri, XML_URI_STRING);
+      if (err)
+	{
+	  sqlr_resignal (err);
+	  return;
+	}
     }
   if (NULL == THR_TMP_POOL) /* outside of parser, caller must take care to set THR mem pool*/
     return;


### PR DESCRIPTION
## Summary

- Retries transient cache/HTTP failures once before propagating the error, instead of silently parsing terms without the requested JSON-LD context.
- Adds cached resource entries for the #-suffixed ActivityStreams namespace URIs so both forms resolve to the same context.
- Keeps the parser and its context resolution in the caller transaction so a test cannot race the vectorized loader worker queue while comparing graphs.

Split out from PR #1465 (fuzzy search) per review feedback — these changes are unrelated to fuzzy search.

#### Test plan
- [ ] JSON-LD test suite (tjsonld.sql) passes
- [ ] ActivityStreams context resolves for both # and non-# namespace URIs

Generated with [Devin](https://devin.ai)